### PR TITLE
Syllabus for CM2045 Professional Practice for Computer Scientists

### DIFF
--- a/modules/syllabi/Syllabus_CM2045_PPCS.md
+++ b/modules/syllabi/Syllabus_CM2045_PPCS.md
@@ -1,0 +1,55 @@
+# Professional Practice for Computer Scientists
+
+## Module description
+This module bridges theoretical knowledge and practical skills essential in computing-related professions. It helps student to develop critical judgment through a legal, ethical, and sustainability lens, fostering a holistic understanding of computing's societal impacts. The emphasis on effective communication, teamwork, and project management prepares students for real-world problem-solving, analysis, and system development, working within diverse teams. Through continuous professional development planning, students are equipped for a lifelong learning trajectory in computer science.  
+
+The professional practice module prepares students for post-graduation computing careers by enhancing their technical education with broader professional skills. It introduces foundational ethical, legal, and regulatory principles, emphasising responsible computing practices. Students will refine their communication skills, essential for teamwork and stakeholder engagement. The module explores sustainability, ethics, and risk management in computing, teaching students to identify and mitigate potential issues. Students also learn about industry standards and best practices for consistent, quality work. students learn about teamwork and strategies to operate in collaborative projects. The module concludes with a focus on career planning and lifelong learning.  
+
+This module contains embedded career development insights and both employer and alumni voice content from your University of London Careers Service distributed across the topics. They highlight the value of the Global Employability Skills you are developing in this module and provide guidance on how to develop your career strategy, whatever your career stage or region.
+
+## Module goals and objectives
+Upon successful completion of this module, you will be able to: 
+1. Communicate technical and non-technical concepts clearly and effectively through written, verbal, and visual mediums using proper etiquette. 
+2. Explain key laws, regulations, and ethical codes applicable to computing professionals and apply them to example scenarios to demonstrate compliant practices. 
+3. Recognize and discuss sustainability impacts of computing such as e-waste and energy usage, and propose improvements aligned with ethical principles. 
+4. Evaluate computing systems and data for biases and accessibility issues, and recommend inclusive solutions that support equality, diversity, and inclusion. 
+5. Apply risk management processes to identify, analyse, and mitigate risks and uncertainties in a computing project scenario. 
+6. Select appropriate project management methods and tools to allow for constructive team collaboration and exhibit professional teamwork and communication skills. 
+7. Develop and follow a plan for continuous skill development and professional advancement in the computing field. 
+
+## Textbook and readings
+This module makes use of a wide range of reading material which you will encounter as you work through the module. The material is available via the online library, and it includes journal and magazine articles as well as some textbook references. The reading list can be found under the Resources section for this module.
+
+## Module outline
+| Topic | Learning outcomes |
+| -- | -- |
+| 1: Written communication skills | Recognise the fundamental elements of effective public speaking and apply techniques to manage speaking. <br> Create structured and engaging presentation content that clearly conveys key messages to diverse audiences. <br> Evaluate and improve presentation techniques by analysing examples and participating in reflective discussions and quizzes. |
+| 2: Presentation and public speaking skills | Recognise the fundamental elements of effective public speaking and apply techniques to manage speaking. <br> Create structured and engaging presentation content that clearly conveys key messages to diverse audiences. Evaluate and improve presentation techniques by analysing examples and participating in reflective discussions and quizzes. |
+| 3: Legal and ethical foundations | Describe key legal and ethical principles relevant to computing professionals and their responsibilities in various scenarios. <br> Analyse the impact of intellectual property laws on the computing industry through case studies and examples. <br> Evaluate ethical challenges in computing and propose solutions aligned with legal and ethical standards. |
+| 4: Inclusive computing and ethical impacts | Identify the importance of diversity and inclusion in the design and development of computing systems. <br> Assess the ethical implications of emerging technologies, including AI, in terms of societal and individual impacts. <br> Explore methods for improving the accessibility of technology to promote inclusivity for diverse user groups. |
+| 5: Sustainability in computing | Identify the environmental impacts of computing systems, including energy consumption and e-waste. <br> Explore strategies for designing sustainable software and hardware solutions that minimise environmental footprints. <br> Evaluate sustainability and impact in the context of the computing industry. |
+| 6: Risk management and security | Describe the fundamental principles of risk management in computing, including identifying and assessing potential risks. <br> Analyse cybersecurity threats and evaluate effective risk mitigation strategies to protect information systems. <br> Apply risk management frameworks, to assess security risks and ensure compliance with industry standards. |
+| 7: Industry standards and best practices | Evaluate the importance of adhering to industry standards through case studies and real-world scenarios. <br> Explore the ethical guidelines outlined by the ACM Code of Ethics and their application in professional decision-making. <br> Describe the role of industry standards, provided by bodies such as IEEE and the ACM, in guiding best practices within the computing profession. |
+| 8: Teamwork and collaboration | Develop communication skills essential for working in diverse and cross-functional teams. <br> Analyse case studies of successful and failed team projects to identify best practices for collaboration in professional environments. <br> Describe the principles of effective collaboration in computing projects and the factors that contribute to successful teamwork. |
+| 9: Project management | Apply project management techniques to effectively plan, execute and monitor the progress of team-based projects. <br> Analyse case studies to identify challenges and best practices in implementing Agile project management in real-world scenarios. <br> Explain the key concepts of project management methodologies, such as Scrum and Kanban, and their application in computing projects. |
+| 10: Professional development and career planning | Develop skills in crafting effective online portfolios of work. <br> Evaluate case studies of career transitions to identify best practices for navigating professional growth and opportunities. <br> Recognise the importance of professional development and strategies for building a successful career in the computing field. |
+
+# Learning activities of this module
+The module is comprised of the following elements: 
+- **Lecture videos**. In each topic, you will find a sequence of videos. 
+- **Readings**. Each topic may include several suggested readings. These are a core part of your learning, and, together with the videos, will cover all the concepts you need for this module. 
+- **Practice assignments**. Each topic will include practice assignments, intended for you to assess your understanding of the topics. You will be allowed unlimited attempts at each practice quiz. There is no time limit on how long you take to complete each attempt at the quiz. These quizzes do not contribute toward your final score in the class. 
+- **Discussion prompts**. Each topic includes discussion prompts. You will see the discussion prompt alongside other items in the lesson. Each prompt provides a space for you to respond. After responding, you can see and comment on your peers' responses. All prompts and responses are also accessible from the general discussion forum and the module discussion forum.
+- **Peer review assignments**. Some topics include a practice peer review assignment. You will be asked to submit a piece of work and then review three of your peers’ submissions. You can attempt these assignments multiple times. The marks from these peer reviews do not count towards your overall grade.
+
+## How to pass this module
+The module will contain a range of summative and formative assessments. Summative assessments are assessments which contribute directly towards your final grade. Formative assessments do not count directly towards your final grade. Instead, they provide you with opportunities for low stakes practice and will often provide some sort of feedback about your progress. For example, a practice quiz might provide you with feedback about why a particular answer was wrong. 
+
+The module has two assessments: a midterm coursework and an end-of-term exam, both worth 50%.
+
+This is a detailed breakdown of all of the marks:
+
+| Activity | Required? (Summative) | Deadline week | Estimated time per module | % of final grade |
+| -- | -- | -- | -- | -- |
+| Written, staff graded coursework | Yes | Approximately week 13 | 20 hours | 50% |
+| Written examination | Yes | Approximately week 22 | 3-4 hours | 50% |


### PR DESCRIPTION
This markdown document contains the verbatim content of the syllabus as this information is not provided as a PDF document.

Is it fine to use the abbreviation "PPCS" for this module?